### PR TITLE
Add IoT-focused profile with specialized resume content

### DIFF
--- a/.env.iot
+++ b/.env.iot
@@ -1,0 +1,1 @@
+RESUME_SUBJECT="IoT Engineer, Embedded Systems, LoRaWAN, Smart Home, Cloud & Edge Computing"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Step 3 - Generate the documents using Docker
         run: |
           ./Scripts/build.sh
+          ./Scripts/build.sh --profile=iot
           ls -lisah Results
 
       - name: Step 4.1 - Upload the single PDF Introduction artifact
@@ -60,6 +61,21 @@ jobs:
           if-no-files-found: error
           retention-days: 12
 
+      - name: Step 6.1 - Upload the IoT PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-pdf-iot
+          path: Results/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.pdf
+          if-no-files-found: error
+          retention-days: 12
+      - name: Step 6.2 - Upload the IoT EPUB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-epub-iot
+          path: Results/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.epub
+          if-no-files-found: error
+          retention-days: 12
+
   release:
     name: release – ${{ github.ref_name }}
     runs-on: ubuntu-latest
@@ -96,6 +112,16 @@ jobs:
         with:
           name: resume-pdf-portfolio
           path: ${{ env.RESUME_FILENAME }}-portfolio
+      - name: Step 2.6 Download IoT PDF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: resume-pdf-iot
+          path: resume-pdf-iot
+      - name: Step 2.7 Download IoT EPUB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: resume-epub-iot
+          path: resume-epub-iot
       - name: Step 3. Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -120,9 +146,16 @@ jobs:
 
             | Document     | Download |
             | ------------ | -------- |
-            | Introduction | [![Badge CV](https://img.shields.io/badge/DE-Introduction-100000?style=for-the-badge&labelColor=4E4796&color=DBD7FF)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.RESUME_FILENAME }}-introduction-${{ github.ref_name }}.pdf) | 
-            | CV           | [![Badge CV](https://img.shields.io/badge/DE-CV-100000?style=for-the-badge&labelColor=4E4796&color=DBD7FF)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.RESUME_FILENAME }}-curriculum-vitae.-${{ github.ref_name }}pdf) | 
+            | Introduction | [![Badge CV](https://img.shields.io/badge/DE-Introduction-100000?style=for-the-badge&labelColor=4E4796&color=DBD7FF)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.RESUME_FILENAME }}-introduction-${{ github.ref_name }}.pdf) |
+            | CV           | [![Badge CV](https://img.shields.io/badge/DE-CV-100000?style=for-the-badge&labelColor=4E4796&color=DBD7FF)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.RESUME_FILENAME }}-curriculum-vitae.-${{ github.ref_name }}pdf) |
             | Portfolio    | [![Badge CV](https://img.shields.io/badge/DE-Portfoilo-100000?style=for-the-badge&labelColor=4E4796&color=DBD7FF)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.RESUME_FILENAME }}-portfolio-${{ github.ref_name }}.pdf) |
+
+            ##### IoT Focus
+
+            | Format | Download |
+            | ------ | -------- |
+            | PDF    | [![Badge IoT PDF](https://img.shields.io/badge/PDF-IoT-100000?style=for-the-badge&labelColor=2E7D32&color=A5D6A7)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.pdf) |
+            | EPUB   | [![Badge IoT EPUB](https://img.shields.io/badge/EPUB-IoT-100000?style=for-the-badge&labelColor=2E7D32&color=A5D6A7)](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.epub) |
 
           draft: false
           prerelease: false
@@ -177,4 +210,24 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./resume-epub/resume-${{ env.RESUME_FILENAME }}-${{ github.ref_name }}.epub
           asset_name: resume-${{ env.RESUME_FILENAME }}-${{ github.ref_name }}.epub
+          asset_content_type: application/epub
+      - name: Step 6.1 Upload IoT PDF Release Asset
+        id: upload-release-asset-pdf-iot
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./resume-pdf-iot/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.pdf
+          asset_name: resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.pdf
+          asset_content_type: application/pdf
+      - name: Step 6.2 Upload IoT EPUB Release Asset
+        id: upload-release-asset-epub-iot
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./resume-epub-iot/resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.epub
+          asset_name: resume-${{ env.RESUME_FILENAME }}-iot-${{ github.ref_name }}.epub
           asset_content_type: application/epub

--- a/Content/Profiles/iot/0-introduction.md
+++ b/Content/Profiles/iot/0-introduction.md
@@ -1,0 +1,87 @@
+# Einführung
+
+> [Einführung](./0-introduction.md) | [Lebenslauf](./1-curriculum-vitae.md) | [Portfolio](./2-portfolio.md) | [Kontakt](3-contact.md)
+
+![REPLACE_NAME](Media/andrelademann.png){ width=42% }
+
+Ein Lebenslauf ist wie ein [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction) – man versteht ihn erst richtig, wenn man genau hinschaut.
+
+
+## Über mich
+
+Ich bin leidenschaftlicher **IoT-Engineer** und **Cloud-Engineer** mit
+tiefer Leidenschaft für die Verbindung von Hardware und Software. Mit
+**Mikrocontrollern**, **LoRaWAN** und **Edge Computing** bringe ich
+physische Systeme in die Cloud.
+**Die Faszination für die Verschmelzung von Software und Hardware motiviert mich,
+neue Protokolle, Plattformen und Produkte aktiv mitzugestalten.**
+
+Als **Organisator der [LoRaWAN Leipzig Usergroup][meetup-lorawan]** bringe ich
+regelmäßig Entwickler, Maker und Unternehmen zusammen, um Erfahrungen rund um
+IoT und LoRaWAN auszutauschen.
+
+Mit **[regenfass.eu][regenfass]** entwickle ich ein eigenes IoT-Produkt für
+Smart-Home-Anwendungen – von der Firmware auf dem Mikrocontroller bis zur
+Cloud-Plattform für Datenvisualisierung und -steuerung.
+
+In meiner beruflichen Laufbahn konnte ich mit internationalen Teams arbeiten und
+Projekte in verschiedenen Ländern realisieren. Als **Cloud- und
+Software-Engineer** bei [Thinkport][thinkport] setze ich skalierbare,
+beobachtbare Backend-Systeme um, die auch in IoT-Kontexten eingesetzt werden.
+
+Seit 2025 bin ich Mitgründer der **[kieks.me GbR][kieksme]**, einer Consulting-
+und Freelance-GbR für Web-Entwicklung und SaaS-Lösungen.
+
+**Meine Schwerpunkte:**
+1. IoT-Systemarchitektur (Firmware → Gateway → Cloud)
+2. Embedded-Entwicklung & Mikrocontroller (ESP32, Raspberry Pi, LoRa)
+3. Cloud-Engineering & Edge Computing
+4. Observability für vernetzte Systeme
+5. Softwarearchitektur & Beratung
+
+
+## Aufgabenschwerpunkte im Verlauf der Zeit
+
+Im Verlauf der Zeit haben sich meine Themenschwerpunkte mehrfach verlagert.
+Die folgende Grafik veranschaulicht dies gut. 2023 gab es einen starken
+Fokus auf Softwareentwicklung und Cloud-Engineering. Im Jahr 2024 habe ich mich
+zusätzlich auf Observability und IoT spezialisiert.
+
+![Fokus-Schwerpunkte im Laufe der Zeit](Media/knowledge-focus-timeline.svg "Fokus-Schwerpunkte im Laufe der Zeit"){ width=100% }
+
+## Skills
+
+### IoT & Embedded Systems
+
+- Firmware-Entwicklung (C/C++, MicroPython)
+- LoRaWAN / MQTT / CoAP
+- Sensor-Integration & Hardware-Prototyping
+- Edge Computing & Gateway-Entwicklung
+
+### Cloud & Backend
+
+- Cloud-Architekturen (AWS, Azure)
+- Containerisierung (Docker, Kubernetes)
+- Observability (OpenTelemetry, Grafana, InfluxDB)
+- Infrastructure as Code
+
+### Beratung & Softwarearchitektur
+
+- IoT-Systemdesign (End-to-End)
+- Projektmanagement
+- Schulungen & Workshops
+
+## Technologie-Stack
+
+IoT, LoRaWAN, MQTT, ESP32, Raspberry Pi, Tasmota, Node-RED, InfluxDB, Grafana,
+OpenTelemetry, IIoT, C++, MicroPython, TypeScript, JavaScript, Docker,
+Kubernetes, AWS, Azure, Flutter, Dart, Node.js, Git, Continuous Integration (CI),
+Ansible, Crossplane, Firebase, Nginx
+
+> **Mehr davon?** In meinem [Lebenslauf](./1-curriculum-vitae.md) und
+> [Portfolio](./2-portfolio.md) gehe ich auf weitere Details ein.
+
+[meetup-lorawan]: https://www.meetup.com/de-DE/lorawan-leipzig-usergroup
+[regenfass]: https://docs.regenfass.eu/
+[kieksme]: https://kieks.me/
+[thinkport]: https://thinkport.digital/

--- a/Content/Profiles/iot/2-portfolio.md
+++ b/Content/Profiles/iot/2-portfolio.md
@@ -1,0 +1,509 @@
+# Portfolio
+
+> [Einführung](./0-introduction.md) | [Lebenslauf](./1-curriculum-vitae.md) | [Portfolio](./2-portfolio.md) | [Kontakt](3-contact.md)
+
+## Projektübersicht
+
+- **IoT & Embedded Systems**
+    - [regenfass.eu](#-regenfasseu) IoT Smart-Home-Eigenprodukt
+    - [CoffeeBin](#-CoffeeBin) Sensor-Datenerfassung und Analytics
+    - [Digitaler Agenturkicker](#-Digitaler-Agenturkicker) IoT Multichannel-Experiment
+
+- **Cloud & Observability**
+  - [EDEKA - Observability PoC](#-EDEKA-Observability-PoC)
+    OpenTelemetry im SAP-Kontext
+  - [EDEKA - Kassensoftware Integration](#-EDEKA-POS-Integration)
+    Integration der Gebit-Kassenlösung für EDEKA
+
+- **App-Entwicklung**
+    - [Flughafen Leipzig/Halle Nachbarschaftsportal](#-lej-nachbarn-app) App-Entwicklung
+    - [Tap!Tap!](#-tap-tap) App-Entwicklung
+    - [CamFight](#-CamFight) Mobile Web App
+
+- **Webentwicklung**
+    - [kieks.me](#-kieksme) Consulting- und Freelance-GbR
+    - [AIDA board portal](#-AIDA-board-portal) Gästeportal für AIDA Cruises
+    - [dynamo-dresden.de](#-dynamo-dresdende) High-Performance-Webanwendung
+    - [Blugento](#-blugento) Docker, Marketing-Automation, AWS
+
+- **CI/CD**
+    - [Universal Music - Shop-Manager](#-universal-music--shop-manager) Schulungen, Docker, CI/CD, Cloud (AWS, Azure)
+
+- **[Weitere Projekte](#-Weitere-Projekte)**
+    - [Bashlight](#-Bashlight) Kommandozeilen-Erweiterung
+
+---
+
+## IoT & Embedded Systems
+
+### [[↑](#projektübersicht)] regenfass.eu
+
+_2024 – heute_
+
+**regenfass.eu** ist ein IoT-Eigenprodukt für Smart-Home-Anwendungen. Das
+Produkt verbindet Hardware-Sensoren mit einer Cloud-basierten Datenplattform
+zur Überwachung und Steuerung von Smart-Home-Komponenten. Die gesamte Kette –
+von der Firmware auf dem Mikrocontroller über das LoRaWAN-Gateway bis zur
+Cloud-API und Visualisierung – wird eigenständig entwickelt und betrieben.
+
+**Meine Aufgaben:** Produktentwicklung, Firmware-Entwicklung, Cloud-Architektur,
+IoT-Integration, Dokumentation.
+
+| Technologische Highlights      |                                  |
+|--------------------------------|----------------------------------|
+| IoT / Mikrocontroller (ESP32)  | Firmware & Hardware-Integration  |
+| LoRaWAN / MQTT                 | Gerätekommunikation              |
+| [Node-RED][node-red]           | Datenfluss & Automation          |
+| [InfluxDB][influxdb]           | Zeitreihenspeicherung            |
+| [Grafana][grafana]             | Datenvisualisierung              |
+| [OpenTelemetry][opentelemetry] | Observability                    |
+
+| Links         |                              |
+|---------------|------------------------------|
+| Dokumentation | <https://docs.regenfass.eu/> |
+
+---
+
+### [[↑](#projektübersicht)] CoffeeBin
+
+_2020_
+
+![img.png](Media/Portfolio/coffee-bin-nodered.png)
+
+Big-Data-Applikation zur Erfassung von Kaffee-Trink-Daten bei
+[Netresearch DTT GmbH][netresearch]. Ein Taster am Kaffeevollautomaten sendet
+via WLAN einen Event. Die Daten werden in einer zeitbasierten Datenbank
+gespeichert. Das Interessante daran ist, welche Schlüsse man aus den zunächst
+banal erscheinenden Daten ziehen kann – z.B. lässt sich ein Stresslevel
+ablesen, wenn man die Daten mit JIRA-Ticket-Volumina korreliert.
+
+**Technologische Highlights:** Firmware in C++ (Tasmota) auf einem ESP8266,
+Node-RED zur Steuerung und Verarbeitung der Datenströme, InfluxDB als
+Zeitreihendatenbank, Grafana zur Visualisierung.
+
+![CoffeeBin Dashboard](Media/Portfolio/coffee-bin.png)
+
+| Technologische Highlights         |                                                                                                      |
+|-----------------------------------|------------------------------------------------------------------------------------------------------|
+| [Tasmota][tasmota]                | C++ Firmware zur Sensor-Datenerfassung (ESP8266)                                                     |
+| [Node-RED][node-red]              | zur Steuerung von Events und Versenden von Nachrichten an Twitter und den firmeninternen Slack-Chat  |
+| [InfluxDB][influxdb]              | zeitbasierte Speicherung der Daten                                                                   |
+| [Grafana][grafana]                | zur Visualisierung der Daten                                                                         |
+
+### [[↑](#projektübersicht)] Digitaler Agenturkicker
+
+_2015 - 2016_
+
+![](Media/Portfolio/piball-header.png)
+![](Media/Portfolio/piball.png)
+
+Die Digitalisierung des Agentur-Kickers ist ein *Multichannel-Experiment*,
+das im Rahmen meiner Research-&-Development-Zeit bei der [Netresearch DTT
+GmbH][netresearch] entstanden ist. Ziel war es, möglichst viele Ausspielkanäle
+mit einer zentralen Datenbasis zu bedienen. Besondere Herausforderung: die
+Integration von Hardware-Komponenten (Raspberry Pi, Gabellichtschranken) und
+das Flottenmanagement von dockerisierten Anwendungen auf ARM-Architektur.
+
+| Technologische Highlights                                 |                                                                                                                                                                    |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Docker][docker]                                          | auf einer ARM-Architektur (Raspberry Pi)                                                                                                                           |
+| [Python][python]                                          | zum Ansprechen von Hardware-Komponenten (GPIO, Gabellichtschranken)                                                                                                |
+| [Google Firebase][google-firebase]                        | Echtzeit-Datenbank für Spielstände                                                                                                                                 |
+| [Node-RED][node-red]                                      | zur Steuerung von Events und Versenden von Nachrichten                                                                                                             |
+| [Vue.js][vue.js]                                          | Anzeigeoberfläche                                                                                                                                                  |
+| [Ionic Framework][ionic-framework]                        | native App für iOS und Android                                                                                                                                     |
+| [Google Chrome Extension][google-chrome-extension-piball] | zur Anzeige der Ergebnisse direkt im Browser                                                                                                                       |
+| [Belana.io][belana.io]                                    | Flottenmanagement der dockerisierten Anwendung                                                                                                                     |
+
+[google-chrome-extension-piball]: https://chrome.google.com/webstore/detail/piball/ejahllipniehmpdjkfjmhhadeeamdebh?authuser=1&gclid=Cj0KCQiAqvaNBhDLARIsAH1Pq53cYjAiaEGVxuANGCggDpF6nSdgcij-7fla8VVSs3KuESNg-YiemskaAgZREALw_wcB
+
+| Links                                                     |                                                      |
+|-----------------------------------------------------------|------------------------------------------------------|
+| Präsentation                                              | <https://prezi.com/khpva--2yv25/foosball/?present=1> |
+| GitHub Repository                                         | <https://github.com/vergissberlin/piball>            |
+| Web interface                                             | <https://vivid-fire-2266.web.app>                    |
+
+---
+
+## Cloud & Observability
+
+### [[↑](#projektübersicht)] Observability EDEKA PoC
+
+_2023_
+
+EDEKA möchte mehr Transparenz in seine Prozesse bringen. Viele Microservices
+laufen in einem Orchester ohne Dirigenten. Mit der Observability-Plattform
+wird es möglich, die Prozesse zu überwachen und bei Bedarf zu
+intervenieren. In diesem PoC galt es, den Nachweis der Machbarkeit zu liefern,
+dass OpenTelemetry im SAP-Kontext eingesetzt werden kann.
+
+**Meine Aufgaben** waren die Team- und Projektleitung. Ich habe die
+Softwarearchitektur entwickelt und die Installation der Software auf den
+Demonstrationsservern durchgeführt.
+
+| Technologische Highlights          |                |
+|------------------------------------|----------------|
+| [OpenTelemetry][opentelemetry]     | Im SAP-Kontext |
+| [Jaeger][jaeger]                   | Tracing        |
+| [Prometheus][prometheus]           | Monitoring     |
+| [DataDog][datadog]                 | Observability  |
+
+### [[↑](#projektübersicht)] kieks.me
+
+_2025 – heute_
+
+**[kieks.me][kieksme]** ist eine Consulting- und Freelance-GbR für
+Web-Entwicklung, SaaS-Websites, Corporate Design und Landing Pages,
+die ich 2025 mitgegründet habe.
+
+**Meine Aufgaben:** Mitgründer, Softwarearchitektur, Full-Stack-Entwicklung.
+
+| Technologische Highlights |                           |
+|---------------------------|---------------------------|
+| [TypeScript][typescript]  | Frontend & Backend        |
+| [Vue.js][vue.js]          | Frontend-Entwicklung      |
+| [Node.js][nodejs]         | Backend-Entwicklung       |
+
+| Links   |                         |
+|---------|-------------------------|
+| Website | <https://kieks.me/>     |
+
+---
+
+### [[↑](#projektübersicht)] AIDA board portal
+
+_2013-2016_
+
+![AIDA Bordportal](Media/Portfolio/aida-bordportal.png)
+
+Das AIDA-Bordportal ist auf AIDA-Schiffen installiert und dient Gästen und
+Besatzung zur Orientierung und zur Buchung von Ausflügen und Restaurantplätzen.
+Es ist optimiert für TV, Mobile und spezielle Displays in den Gängen.
+
+**Meine Aufgaben** waren die Team- und Projektleitung, die Installation der
+Software auf dem Schiff und die Erstellung eines Demosystems.
+
+| Technologische Highlights          |                                    |
+|------------------------------------|------------------------------------|
+| [Docker-Registry][docker-registry] | auf GitLab                         |
+| [Docker Compose][docker-compose]   | für verschiedene Environments      |
+| [AWS ECS][aws-ecs]                 | für das Container-Deployment       |
+| [AWS EC2][aws-ec2]                 | für das Container-Deployment       |
+| [AWS EFS][aws-efs]                 | zum verteilten Speichern von Daten |
+| [AWS RDS][aws-rds]                 | zum Datenbank-Deployment           |
+| [Concourse CI][concourse-ci]       | als Pipeline-Tool für CI/CD        |
+
+| Links |                                    |
+|-------|------------------------------------|
+| Demo  | (nicht öffentlich verfügbar)       |
+
+
+### [[↑](#projektübersicht)] dynamo-dresden.de
+
+_2014 - 2015_
+
+![Dynamo Dresden Website](Media/Portfolio/dynamo-dresden.png)
+
+Als technischer Leiter war ich für die Planung verantwortlich. Ich war Teil
+des Pitches. Außerdem war ich verantwortlich für Lasttests und
+Leistungsverbesserungen.
+
+| Technologische Highlights                |                         |
+|------------------------------------------|-------------------------|
+| [Varnish][varnish]                       | Reverse Proxy           |
+| [Edge Side Includes][edge-side-includes] | Edge Side Includes      |
+| [Load Testing][jmeter]                   | Lasttests mit JMeter    |
+| [TYPO3][typo3]                           | TYPO3 CMS               |
+
+| Links                                                     |                                                              |
+|:----------------------------------------------------------|--------------------------------------------------------------|
+| Website                                                   | <https://www.dynamo-dresden.de>                              |
+| Chrome Extensions Dynamo                                  | <https://chrome.google.com/webstore/search/dynamo%20dresden> |
+
+
+## Softwareentwicklung
+
+### [[↑](#projektübersicht)] EDEKA POS Integration
+
+_2023_ - `now()`
+
+Der Kunde beauftragte die Gebit mit der Integration der Kassenlösung in die
+EDEKA-Infrastruktur und beauftragte Thinkport als technischen Dienstleister.
+
+Die **Technologie-Highlights** sind **Flutter** für die App-Entwicklung,
+**Java** für die Backend-Entwicklung und **Docker** für die Bereitstellung der
+Anwendung. **OpenTelemetry** wird für die Observability eingesetzt.
+
+| Technologische Highlights      |                              |
+|--------------------------------|------------------------------|
+| [Flutter][flutter]             | Frontend-Entwicklung         |
+| [Java][java]                   | Backend-Entwicklung          |
+| [Kubernetes][kubernetes]       | Bereitstellung der Anwendung |
+| [OpenTelemetry][opentelemetry] | Observability                |
+
+### [[↑](#projektübersicht)] LEJ Nachbarn App
+
+_2022_
+
+![LEJ Nachbarn App](Media/Portfolio/lejn-store-ios.png)
+
+Der Kunde Flughafen Leipzig/Halle suchte eine Möglichkeit, mit seinen direkten
+Nachbarn auf digitalem Weg ins Gespräch zu kommen. Mein Part war die Umsetzung
+der App-Variante. **React Native** zeigt hier seine Stärken, da die App für
+iOS und Android entwickelt werden konnte und somit die Kosten für die
+Entwicklung deutlich gesenkt werden konnten.
+
+![LEJN Pipeline](Media/Portfolio/lejn-pipeline.png)
+
+Teil des Projektes war die Erstellung einer CI/CD-Pipeline mit GitLab CI.
+
+| Technologische Highlights              |                                  |
+|----------------------------------------|----------------------------------|
+| [React Native][react-native]           | auf GitLab                       |
+| [Expo][expo]                           | zur App-Entwicklung im Browser   |
+| [Google Play Store][google-play-store] | Veröffentlichung der Anwendung   |
+| Push-Benachrichtigungen                | Push-Benachrichtigungen mit Expo |
+
+| Links             |                                                                        |
+|-------------------|------------------------------------------------------------------------|
+| Google Play Store | <https://play.google.com/store/apps/details?id=com.netresearch.portal> |
+| Apple AppStore    | <https://apps.apple.com/de/app/lej-nachbarn/id1620877158?uo=4>         |
+
+
+### [[↑](#projektübersicht)] Tap! Tap!
+
+_2020_
+
+![Tap! Tap! Play store](Media/Portfolio/tap-tap.png)
+
+Dies ist ein **React Native** Game-Experiment.
+
+| Technologische Highlights              |                                |
+|----------------------------------------|--------------------------------|
+| [React Native][react-native]           | auf GitLab                     |
+| [Expo][expo]                           | zur App-Entwicklung im Browser |
+| [Google Play Store][google-play-store] | Veröffentlichung der Anwendung |
+
+| Links             |                                                                          |
+|-------------------|--------------------------------------------------------------------------|
+| Website           | <https://taptap.andrelademann.de>                                        |
+| Repository        | <https://github.com/vergissberlin/tap-tap->                              |
+| Google Play Store | <https://play.google.com/store/apps/details?id=com.vergissberlin.taptap> |
+
+### [[↑](#projektübersicht)] Bashlight
+
+![Bashlight](Media/Portfolio/bashlight.png)
+
+Eine Erweiterung der Kommandozeilen-Eingabeaufforderung, die unter anderem den
+Git-Zweig und den Git-Status anzeigt.
+
+| Technologische Highlights |                                    |
+|---------------------------|------------------------------------|
+| [bash scripting][bash]    | Prompt, Git, Testing, Auto-Update  |
+
+| Links         |                                              |
+|---------------|----------------------------------------------|
+| Dokumentation | <http://vergissberlin.github.io/bashlight/>  |
+| Repository    | <https://github.com/vergissberlin/bashlight> |
+
+
+### [[↑](#projektübersicht)] Blugento
+
+_2017 - 2018_
+
+![blugento](Media/Portfolio/blugento.png)
+
+Blugento ist ein Verwaltungssystem für Docker-Anwendungen auf entfernten Servern.
+
+| Technologische Highlights                                 |                                                                         |
+|-----------------------------------------------------------|-------------------------------------------------------------------------|
+| [Docker-API][docker]                                      | Starten und Stoppen von Anwendungen auf Remote-Systemen                 |
+| [Docker Compose][docker-compose]                          | für verschiedene Environments                                           |
+| [GraphQL][graphql]                                        | mit [Apollo.js][apollojs] zur Bereitstellung nutzerbasierter Daten      |
+| [Vue.js][vue.js]                                          | Frontend                                                                |
+| [AWS ECS][aws-ecs] / [AWS EC2][aws-ec2]                   | Container-Deployment                                                    |
+
+| Links                                                     |                            |
+|-----------------------------------------------------------|----------------------------|
+| Website                                                   | <https://blugento.com>     |
+
+
+### [[↑](#projektübersicht)] CamFight
+
+_2017_
+
+![Camp Fight Prototyp](Media/Portfolio/cam-fight.png)
+
+Web-App für ein Team-Event – eine digitalisierte Fotorallye. Rapid Prototyping
+mit Papierprototypen und Figma direkt mit dem Kunden.
+
+| Technologische Highlights        |                                                   |
+|----------------------------------|---------------------------------------------------|
+| [Vue.js][vue.js]                 | Mobile App mit der Vuetify-Komponentenbibliothek  |
+| [AWS S3][aws-s3]                 | Zum Upload der Fotos durch die Nutzer             |
+| [Travis CI][travis-ci]           | als Pipeline-Tool für CI/CD                       |
+
+| Links                            |                                              |
+|----------------------------------|----------------------------------------------|
+| App                              | <https://cam-fight.surge.sh>                 |
+| Repository                       | <https://github.com/vergissberlin/cam-fight> |
+
+
+## DevOps
+
+### [[↑](#projektübersicht)] Universal Music – Shop Manager
+
+_2018-2019_
+
+![Universal Music](Media/Portfolio/umg.png)
+
+Release-Management eines Docker-Basis-Images innerhalb eines internationalen
+Teams (Australien, USA, Indien). Schulungen zur entwickelten Software.
+
+| Technologische Highlights          |                                    |
+|------------------------------------|------------------------------------|
+| [Docker-Registry][docker-registry] | auf GitLab                         |
+| [Docker Compose][docker-compose]   | für verschiedene Environments      |
+| [AWS ECS][aws-ecs]                 | für das Container-Deployment       |
+| [Concourse CI][concourse-ci]       | als Pipeline-Tool für CI/CD        |
+
+| Links                              |                                  |
+|------------------------------------|----------------------------------|
+| Universal Music Group              | <https://www.universalmusic.com> |
+
+## Consulting
+
+### [[↑](#projektübersicht)] KiTa Tagesplaner
+
+_2020 - 2021_
+
+![KiTa Tagesplaner](Media/Portfolio/kita-tagesplaner.png)
+
+Full-Stack-Entwicklung einer PWA für Erzieherinnen und Erzieher zur Beschreibung
+des Tagesablaufs mit Bildern (Drag-and-Drop, Offline-fähig, Dark Mode).
+
+| Technik-Highlights                 |                                              |
+|------------------------------------|----------------------------------------------|
+| [Vue.js][vue.js]                   | Mobile App mit der Vuetify-Komponentenbibliothek |
+| [fastify][fastify]                 | Backend-Framework für Node.js                |
+| [OpenAPI][openapi]                 | REST-API-Generierung und Dokumentation       |
+
+| Links                              |                                                                  |
+|------------------------------------|------------------------------------------------------------------|
+| App                                | <https://kita-tagesplaner.onrender.com>                          |
+| Repository der App                 | <https://github.com/NULLzuEINS/kindergarten-day-planner-app>     |
+
+
+## [[↑](#projektübersicht)] Weitere Projekte
+
+… auf die ich stolz bin.
+
+| Projekt                  |                                                   |
+|:-------------------------|:--------------------------------------------------|
+| Node-RED mjml            | Node-RED-Node zur Gestaltung von E-Mail-Templates |
+| Node-RED say             | Node-RED-Node zur Ausgabe von Sprachnachrichten   |
+
+
+[apollojs]: https://www.apollographql.com/
+
+[autopilot]: https://www.autopilot.io/
+
+[aws-ecs]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_Basics.html
+
+[aws-ec2]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-types.html
+
+[aws-efs]: https://docs.aws.amazon.com/efs/latest/ug/
+
+[aws-rds]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html
+
+[aws-s3]: https://aws.amazon.com/s3/
+
+[bash]: https://www.gnu.org/software/bash/
+
+[belana.io]: https://belana.io/
+
+[concourse-ci]: https://docs.concourse.ci/
+
+[docker]: https://www.docker.com/
+
+[docker-compose]: https://docs.docker.com/compose/
+
+[docker-registry]: https://docs.docker.com/registry/
+
+[edge-side-includes]: https://en.wikipedia.org/wiki/Edge_Side_Includes
+
+[expo]: https://expo.dev/
+
+[fastify]: https://www.fastify.io/
+
+[flutter]: https://flutter.dev/
+
+[google-chrome-extension]: https://chrome.google.com/webstore/detail/google-chrome-extension-for-t/nmmhkkegccagdldgiimedpiccmgmiednk
+
+[google-chrome-extension-dynamo]: https://chrome.google.com/webstore/search/dynamo
+
+[google-firebase]: https://firebase.google.com/
+
+[google-play-store]: https://play.google.com/store/apps/details?id=com.example.taptap
+
+[graphql]: https://graphql.org/
+
+[grafana]: https://grafana.com/
+
+[heroku]: https://dashboard.heroku.com/apps/camfight-app
+
+[hubspot]: https://www.hubspot.com/
+
+[java]: https://www.java.com/
+
+[kubernetes]: https://kubernetes.io/
+
+[influxdb]: https://influxdb.com/
+
+[ionic-framework]: https://ionicframework.com/
+
+[jmeter]: https://jmeter.apache.org/
+
+[jspdf]: https://parall.ax/products/jspdf
+
+[netresearch]: https://www.netresearch.de/
+
+[node-red]: https://nodered.org/
+
+[openapi]: https://swagger.io/specification/
+
+[postman]: https://www.getpostman.com/
+
+[python]: https://www.python.org/
+
+[react-native]: https://reactnative.dev/
+
+[sphinx]: https://www.sphinx-doc.org/
+
+[tasmota]: https://tasmota.github.io/docs/
+
+[travis-ci]: https://travis-ci.org/
+
+[typo3]: https://typo3.org/
+
+[umg]: https://www.universalmusic.com/
+
+[vue.js]: https://vuejs.org/
+
+[varnish]: https://www.varnish-cache.org/
+
+[vuetify]: https://vuetifyjs.com/
+
+[datadog]: https://www.datadoghq.com/
+
+[opentelemetry]: https://opentelemetry.io/
+
+[jaeger]: https://www.jaegertracing.io/
+
+[prometheus]: https://prometheus.io/
+
+[kieksme]: https://kieks.me/
+
+[typescript]: https://www.typescriptlang.org/
+
+[nodejs]: https://nodejs.org/

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -10,6 +10,18 @@
 
 
 ################################################################################
+## Parse arguments
+################################################################################
+
+PROFILE=""
+for arg in "$@"; do
+  case $arg in
+    --profile=*) PROFILE="${arg#*=}" ;;
+  esac
+done
+
+
+################################################################################
 ## Variables
 ################################################################################
 
@@ -29,6 +41,19 @@ else
   set -a
   source .env
   set +a
+fi
+
+# Load profile-specific env overrides if a profile is set
+if [ -n "$PROFILE" ] && [ -f ".env.${PROFILE}" ]; then
+  set -a
+  source ".env.${PROFILE}"
+  set +a
+fi
+
+# Profile suffix for output filenames (empty for default profile)
+PROFILE_SUFFIX=""
+if [ -n "$PROFILE" ]; then
+  PROFILE_SUFFIX="-${PROFILE}"
 fi
 
 ################################################################################
@@ -77,8 +102,18 @@ fi
 # Create temporary directory
 mkdir -p Temp
 
-# Copy all Markdown files from the content directory to the temporary directory
-cp -R Content/* Temp
+# Copy non-markdown assets (Media, etc.) from the content directory
+cp -R Content/Media Temp/ 2>/dev/null || true
+
+# Copy markdown files: use profile override if available, else default
+for file in Content/*.md; do
+  fname=$(basename "$file")
+  if [ -n "$PROFILE" ] && [ -f "Content/Profiles/${PROFILE}/${fname}" ]; then
+    cp "Content/Profiles/${PROFILE}/${fname}" Temp/
+  else
+    cp "$file" Temp/
+  fi
+done
 
 # Create the output directory if it doesn't exist and delete all files in it
 mkdir -p Results
@@ -122,7 +157,7 @@ for file in Temp/*.md; do
 
     echo "👉\tBuild single PDF for \"${title}\""
     docker run -v $PWD:/data ghcr.io/vergissberlin/pandoc-eisvogel-de ${file} \
-      -o Results/${RESUME_FILENAME}-${filename}-${document_git_tag}.pdf \
+      -o Results/${RESUME_FILENAME}${PROFILE_SUFFIX}-${filename}-${document_git_tag}.pdf \
       --defaults Template/Config/defaults-pdf-single.yml \
       --metadata-file Template/Config/metadata-pdf.yml \
       -V title="${title}" \
@@ -139,12 +174,9 @@ done
 
 echo "\n✅\tGenerate PDF with combined content"
 
-# Remove the temporary directory containing the Markdown files
-# rm -rf "Temp/*.md*"
-
-# Combine all Markdown files in the content directory into a single Markdown file
+# Combine all Markdown files from Temp into a single Markdown file
 echo "👉\tCombine all Markdown files into a single Markdown file"
-cat Content/*.md > Temp/combined.md
+cat Temp/*.md > Temp/combined.md
 
 # Filter and replace characters in the single Markdown file
 echo "👉\tFilter and replace characters in single Markdown file"
@@ -157,7 +189,7 @@ sh Scripts/replace.sh Temp/combined.md
 # Generate a single PDF file from all Markdown files in the content directory
 echo "👉\tGenerate PDF for all files"
 docker run -i -v $PWD:/data ghcr.io/vergissberlin/pandoc-eisvogel-de \
-  -o Results/resume-${RESUME_FILENAME}-${document_git_tag}.pdf \
+  -o Results/resume-${RESUME_FILENAME}${PROFILE_SUFFIX}-${document_git_tag}.pdf \
   --defaults Template/Config/defaults-pdf.yml \
   --metadata-file Template/Config/metadata-pdf.yml \
   -V title="${RESUME_NAME}" \
@@ -174,7 +206,7 @@ docker run -i -v $PWD:/data ghcr.io/vergissberlin/pandoc-eisvogel-de \
 # Generate a singe epub file from all Markdown files in the content directory
 echo "👉\tGenerate EPUB for all files"
 docker run -i -v $PWD:/data ghcr.io/vergissberlin/pandoc-eisvogel-de \
-  -o Results/resume-${RESUME_FILENAME}-${document_git_tag}.epub \
+  -o Results/resume-${RESUME_FILENAME}${PROFILE_SUFFIX}-${document_git_tag}.epub \
   --defaults Template/Config/defaults-epub.yml \
   --metadata-file Template/Config/metadata-epub.yml \
   -V title="${RESUME_NAME}" \


### PR DESCRIPTION
## Summary
This PR introduces a profile-based resume generation system with an initial IoT-focused profile. The build system now supports generating specialized resume variants tailored to different professional focuses.

## Key Changes

- **Profile System Implementation**
  - Modified `Scripts/build.sh` to accept `--profile` argument for conditional content selection
  - Added profile-specific environment variable loading via `.env.{profile}` files
  - Implemented profile suffix in output filenames (e.g., `resume-...-iot-....pdf`)

- **IoT Profile Content**
  - Created `Content/Profiles/iot/0-introduction.md` - IoT-focused introduction emphasizing embedded systems, LoRaWAN, and hardware-software integration
  - Created `Content/Profiles/iot/2-portfolio.md` - Comprehensive portfolio (509 lines) highlighting IoT projects including regenfass.eu, CoffeeBin, and Digitaler Agenturkicker
  - Added `.env.iot` with IoT-specific resume subject line

- **Build System Enhancements**
  - Updated `Scripts/build.sh` to intelligently select profile-specific markdown files when available, falling back to defaults
  - Modified asset handling to copy Media directory separately from markdown files
  - Updated CI/CD workflow (`.github/workflows/build-and-release.yml`) to:
    - Build both default and IoT profiles
    - Upload IoT PDF and EPUB artifacts
    - Include IoT downloads in release notes with dedicated section

## Implementation Details

The profile system uses a fallback mechanism: if a profile-specific markdown file exists in `Content/Profiles/{profile}/`, it's used; otherwise, the default file from `Content/` is used. This allows selective content overrides while maintaining backward compatibility.

Output filenames include the profile suffix when building with a profile, enabling multiple variants to coexist in the Results directory.

https://claude.ai/code/session_01PWNGu3Fpk3VKZFPpH9vkYq