### PR TITLE
Add Bewerbung directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 Temp
 Results
+Bewerbung


### PR DESCRIPTION
## Summary
Updated the `.gitignore` file to exclude the `Bewerbung` directory from version control.

## Changes
- Added `Bewerbung` to the list of ignored directories/files

## Details
This change prevents the `Bewerbung` directory from being tracked by Git, keeping it out of the repository alongside other ignored directories like `Temp` and `Results`.

https://claude.ai/code/session_019sLndREzfehXCGNgQBcqaA