### PR TITLE
Fix titlepage-background path casing in PDF IoT config

### DIFF
--- a/Template/Config/defaults-pdf-iot.yml
+++ b/Template/Config/defaults-pdf-iot.yml
@@ -15,7 +15,7 @@ variables:
   titlepage-text-color: 'ffffff'
   titlepage-rule-color: 'A5D6A7'
   titlepage-rule-height: 0
-  titlepage-background: 'Content/Media/cover/Cover-IOT.png'
+  titlepage-background: 'Content/Media/Cover/Cover-IOT.png'
   page-background: 'Template/Backgrounds/background1.pdf'
   fontsize: 10pt
   logo-width: 64mm


### PR DESCRIPTION
## Summary
Corrected the file path casing for the titlepage background image in the PDF IoT configuration file to match the actual directory structure.

## Changes
- Updated `titlepage-background` path from `'Content/Media/cover/Cover-IOT.png'` to `'Content/Media/Cover/Cover-IOT.png'`
  - Changed `cover` directory name to `Cover` (capitalized) to match the actual file system path

## Details
This fix ensures the PDF configuration correctly references the titlepage background image with the proper directory casing, preventing potential file not found errors on case-sensitive file systems.

https://claude.ai/code/session_01VFAg2btzvXSG62MDE6dXjn